### PR TITLE
feat: add incremental scraping via --since flag

### DIFF
--- a/src/scraping/ufc_stats/ufcstats_scraping/spiders/stats_spider.py
+++ b/src/scraping/ufc_stats/ufcstats_scraping/spiders/stats_spider.py
@@ -1,5 +1,6 @@
+from datetime import datetime
 from functools import reduce
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 import scrapy
 from scrapy.http.request import Request
@@ -9,18 +10,61 @@ from ..items import FightData
 
 
 class StatsSpider(scrapy.Spider):
-    """Spider for scraping UFC fight statistics."""
+    """Spider for scraping UFC fight statistics.
+
+    Supports incremental scraping via the ``since`` argument.  Pass a date in
+    ``DD/MM/YYYY`` format to only scrape events *after* that date::
+
+        scrapy crawl stats_spider -a since=14/03/2026
+
+    When ``since`` is omitted the spider performs a full scrape.
+    """
 
     name: str = "stats_spider"
     allowed_domains: List[str] = ["ufcstats.com"]
     start_urls: List[str] = ["http://ufcstats.com/statistics/events/completed?page=all"]
 
+    def __init__(self, *args, since: Optional[str] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if since is not None:
+            self.since: Optional[datetime] = datetime.strptime(since, "%d/%m/%Y")
+            self.logger.info("Incremental mode: scraping events after %s", self.since.date())
+        else:
+            self.since = None
+
+    @staticmethod
+    def _parse_listing_date(text: str) -> Optional[datetime]:
+        """Parse a date string like 'March 28, 2026' from the events listing."""
+        try:
+            return datetime.strptime(text.strip(), "%B %d, %Y")
+        except (ValueError, AttributeError):
+            return None
+
     def parse(self, response: Response, **kwargs) -> Iterator[Request]:
-        """Extract and follow links to all UFC events."""
+        """Extract and follow links to all UFC events.
 
-        events_links: List[str] = response.css("a.b-link.b-link_style_black::attr(href)").getall()
+        When running in incremental mode, events at or before the ``since``
+        date are skipped entirely — no event or fight pages are fetched for
+        them.
+        """
 
-        for event_link in events_links:
+        rows = response.css("tr.b-statistics__table-row")
+        for row in rows:
+            event_link = row.css("a.b-link.b-link_style_black::attr(href)").get()
+            if not event_link:
+                continue
+
+            if self.since is not None:
+                date_text = row.css("span.b-statistics__date::text").get()
+                event_date = self._parse_listing_date(date_text)
+                if event_date is not None and event_date <= self.since:
+                    self.logger.info(
+                        "Skipping event at %s (at or before cutoff %s)",
+                        event_date.date(),
+                        self.since.date(),
+                    )
+                    continue
+
             yield scrapy.Request(url=event_link, callback=self.parse_event)
 
     def parse_event(self, response: Response) -> Iterator[Request]:

--- a/tests/scrapers/test_stats_scraper/test_stats_spider.py
+++ b/tests/scrapers/test_stats_scraper/test_stats_spider.py
@@ -112,6 +112,31 @@ class TestStatsSpider:
             "http://ufcstats.com/fight-details/no-contest-fight",
         ]
 
+    def test_parse_incremental_skips_old_events(self) -> None:
+        """When ``since`` is set, events at or before that date are skipped."""
+
+        # Mock events page has events from December 14, 2024 down to earlier dates.
+        # Setting since to November 16 should skip Nov 16 and everything before it.
+        spider = StatsSpider(since="16/11/2024")
+        responses: List[Request] = list(spider.parse(self.mock_response(self.start_urls)))
+
+        full_spider = StatsSpider()
+        all_responses: List[Request] = list(full_spider.parse(self.mock_response(self.start_urls)))
+
+        assert len(responses) < len(all_responses), (
+            "Incremental spider should yield fewer events than full spider"
+        )
+        # Events on or before Nov 16 should be excluded
+        assert len(responses) > 0, "Should still yield some recent events"
+
+    def test_parse_full_scrape_when_since_omitted(self) -> None:
+        """Without ``since``, all events are scraped."""
+
+        spider = StatsSpider()
+        assert spider.since is None
+        responses: List[Request] = list(spider.parse(self.mock_response(self.start_urls)))
+        assert len(responses) > 0
+
     @pytest.fixture
     def expected_parsed_fight_data(self):
         """Fixture providing expected parsed fight data."""


### PR DESCRIPTION
## Changes

- Add `since` argument to `StatsSpider` to enable incremental scraping by date
- Users can pass a date in `DD/MM/YYYY` format to only scrape events after that date
- Spider now parses event dates from listing rows and skips events at or before the cutoff date
- Add helper method `_parse_listing_date()` to parse date strings from event listings
- Update spider docstring with usage examples
- Add tests to verify incremental mode skips old events and full scrape works without `since` argument

## Implementation Details

- Modified `parse()` method to iterate over table rows and check event dates
- Events at or before the cutoff date are logged and skipped entirely
- Full scrape still works when `since` is omitted (default behavior)
- Supports logging of skipped events for transparency